### PR TITLE
feat: add configuration and Datadog metrics integration for gRPC server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ setup.protoc:
 		else echo "Unsupported architecture: $$ARCH"; exit 1; fi; \
 		PROTOC_ZIP=protoc-$(PROTOC_VERSION)-$$OS-$$ARCH.zip; \
 		curl -Lo /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/$$PROTOC_ZIP; \
-		unzip -o /tmp/protoc.zip bin/protoc -d ./$(PROTOC_BIN_DIR); \
+		unzip -o /tmp/protoc.zip bin/protoc -d ./; \
 		rm -f /tmp/protoc.zip; \
 		echo "protoc installed in $(PROTOC_BIN_DIR)"; \
 		echo "You may want to add this to your PATH:"; \

--- a/internal/logging/slog.go
+++ b/internal/logging/slog.go
@@ -29,8 +29,12 @@ func (l *slogLogger) With(args ...any) Logger {
 }
 
 func Init() Logger {
+	level := slog.LevelInfo
+	if os.Getenv("DEBUG") == "true" {
+		level = slog.LevelDebug
+	}
 	l := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: level,
 	}))
 	slog.SetDefault(l)
 	return &slogLogger{logger: l}

--- a/internal/metrics/datadog/client.go
+++ b/internal/metrics/datadog/client.go
@@ -1,0 +1,41 @@
+package datadog
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+)
+
+type DatadogClient struct {
+	apiKey string
+	appKey string
+	client *http.Client
+}
+
+var ErrMissingCredentials = fmt.Errorf("missing DATADOG_API_KEY or DATADOG_APP_KEY")
+
+func NewDatadogClient() (*DatadogClient, error) {
+	apiKey := os.Getenv("DATADOG_API_KEY")
+	appKey := os.Getenv("DATADOG_APP_KEY")
+	if apiKey == "" || appKey == "" {
+		slog.Error("missing required Datadog credentials: DATADOG_API_KEY or DATADOG_APP_KEY")
+		return nil, ErrMissingCredentials
+	}
+
+	return &DatadogClient{
+		apiKey: apiKey,
+		appKey: appKey,
+		client: &http.Client{Timeout: 5 * time.Second},
+	}, nil
+}
+
+func (d *DatadogClient) SendGauge(metric string, value float64, tags []string) error {
+	payload, err := buildGaugePayload(metric, value, tags)
+	if err != nil {
+		slog.Error("failed to build payload", slog.Any("error", err))
+		return err
+	}
+	return sendToDatadog(d.client, d.apiKey, d.appKey, payload)
+}

--- a/internal/metrics/datadog/payload.go
+++ b/internal/metrics/datadog/payload.go
@@ -1,0 +1,32 @@
+package datadog
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type metricPayload struct {
+	Series []metricSeries `json:"series"`
+}
+
+type metricSeries struct {
+	Metric string       `json:"metric"`
+	Points [][2]float64 `json:"points"`
+	Type   string       `json:"type"`
+	Tags   []string     `json:"tags,omitempty"`
+	Host   string       `json:"host,omitempty"`
+}
+
+// buildGaugePayload constructs the JSON payload for a Datadog gauge metric.
+func buildGaugePayload(metric string, value float64, tags []string) ([]byte, error) {
+	now := float64(time.Now().Unix())
+	p := metricPayload{
+		Series: []metricSeries{{
+			Metric: metric,
+			Points: [][2]float64{{now, value}},
+			Type:   "gauge",
+			Tags:   tags,
+		}},
+	}
+	return json.Marshal(p)
+}

--- a/internal/metrics/datadog/transport.go
+++ b/internal/metrics/datadog/transport.go
@@ -1,0 +1,36 @@
+package datadog
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"net/http"
+)
+
+// sendToDatadog sends the payload to the Datadog metrics API endpoint.
+func sendToDatadog(client *http.Client, apiKey, appKey string, payload []byte) error {
+	req, err := http.NewRequest("POST", "https://api.datadoghq.com/api/v1/series", bytes.NewBuffer(payload))
+	if err != nil {
+		slog.Error("failed to create request", slog.Any("error", err))
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("DD-API-KEY", apiKey)
+	req.Header.Set("DD-APPLICATION-KEY", appKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Error("failed to send request", slog.Any("error", err))
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		slog.Error("datadog returned error", slog.Int("status_code", resp.StatusCode))
+		return fmt.Errorf("datadog returned status: %s", resp.Status)
+	}
+
+	slog.Debug("datadog metric sent successfully")
+	return nil
+}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -1,0 +1,11 @@
+package server
+
+import "time"
+
+type Config struct {
+	Host                string
+	Port                int
+	Timeout             time.Duration
+	ServerID            string
+	DatadogCustomMetric bool
+}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -2,57 +2,23 @@ package server
 
 import (
 	"context"
-	"io"
-	"time"
 
 	pb "github.com/naka-gawa/grpc-benchtool/proto/grpcbench"
 )
 
 type BenchHandler struct {
 	pb.UnimplementedBenchServiceServer
-	ServerID string
+	strategy TestStrategy
 }
 
-func NewBenchHandler(serverID string) *BenchHandler {
-	return &BenchHandler{ServerID: serverID}
+func NewBenchHandler(strategy TestStrategy) *BenchHandler {
+	return &BenchHandler{strategy: strategy}
 }
 
 func (h *BenchHandler) UnaryTest(ctx context.Context, req *pb.TestRequest) (*pb.TestResponse, error) {
-	now := time.Now().UnixNano()
-	latency := now - req.SentUnixNano
-
-	return &pb.TestResponse{
-		ServerId:         h.ServerID,
-		ReceivedUnixNano: now,
-		LatencyNano:      latency,
-	}, nil
+	return h.strategy.HandleUnary(ctx, req)
 }
 
 func (h *BenchHandler) StreamTest(stream pb.BenchService_StreamTestServer) error {
-	var (
-		count    int64
-		total    int64
-		latSumMs float64
-	)
-
-	for {
-		req, err := stream.Recv()
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return err
-		}
-		count++
-		total += int64(len(req.Payload))
-		latencyMs := float64(time.Now().UnixNano()-req.SentUnixNano) / 1e6
-		latSumMs += latencyMs
-	}
-
-	return stream.SendAndClose(&pb.StreamSummary{
-		ServerId:         h.ServerID,
-		ReceivedCount:    count,
-		TotalBytes:       total,
-		AverageLatencyMs: latSumMs / float64(count),
-	})
+	return h.strategy.HandleStream(stream)
 }

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -91,7 +91,7 @@ func TestBenchHandler_UnaryTest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := server.NewBenchHandler("test-server")
+			handler := server.NewBenchHandler(&server.DefaultStrategy{ServerID: "test-server"})
 
 			req := &pb.TestRequest{
 				ClientId:     tt.args.clientID,
@@ -161,7 +161,7 @@ func TestBenchHandler_StreamTest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := server.NewBenchHandler("test-server")
+			handler := server.NewBenchHandler(&server.DefaultStrategy{ServerID: "test-server"})
 
 			stream := &mockStream{recvMsgs: tt.recvMsgs, injectRecvErr: tt.injectErr}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+
+	"github.com/naka-gawa/grpc-benchtool/internal/interceptor"
+	pb "github.com/naka-gawa/grpc-benchtool/proto/grpcbench"
+)
+
+type Server struct {
+	cfg    Config
+	grpc   *grpc.Server
+	listen net.Listener
+}
+
+func New(cfg Config, handler pb.BenchServiceServer) (*Server, error) {
+	addr := net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", cfg.Port))
+	lis, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on %s: %w", addr, err)
+	}
+
+	s := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(
+			interceptor.UnaryRequestIDInterceptor(),
+			interceptor.UnaryLoggingInterceptor(),
+		),
+		grpc.ChainStreamInterceptor(
+			interceptor.StreamRequestIDInterceptor(),
+			interceptor.StreamLoggingInterceptor(),
+		),
+	)
+
+	pb.RegisterBenchServiceServer(s, handler)
+
+	reflection.Register(s)
+
+	return &Server{
+		cfg:    cfg,
+		grpc:   s,
+		listen: lis,
+	}, nil
+}
+
+func (s *Server) Start(ctx context.Context) error {
+	slog.Info("starting gRPC server", slog.String("addr", s.listen.Addr().String()))
+	if err := s.grpc.Serve(s.listen); err != nil {
+		return fmt.Errorf("failed to serve: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) Shutdown(ctx context.Context) {
+	slog.Info("shutting down gRPC server", slog.String("addr", s.listen.Addr().String()))
+
+	done := make(chan struct{})
+	go func() {
+		s.grpc.GracefulStop()
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		slog.Warn("shutdown timeout exceeded, forcing stop")
+		s.grpc.Stop()
+	case <-done:
+		slog.Info("server stopped gracefully")
+	}
+}

--- a/internal/server/strategy.go
+++ b/internal/server/strategy.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/naka-gawa/grpc-benchtool/internal/metrics/datadog"
+	pb "github.com/naka-gawa/grpc-benchtool/proto/grpcbench"
+)
+
+type TestStrategy interface {
+	HandleUnary(ctx context.Context, req *pb.TestRequest) (*pb.TestResponse, error)
+	HandleStream(stream pb.BenchService_StreamTestServer) error
+}
+
+type DefaultStrategy struct {
+	ServerID      string
+	MetricsClient *datadog.DatadogClient
+}
+
+func (s *DefaultStrategy) HandleUnary(ctx context.Context, req *pb.TestRequest) (*pb.TestResponse, error) {
+	now := time.Now().UnixNano()
+	latency := now - req.SentUnixNano
+
+	if s.MetricsClient != nil {
+		_ = s.MetricsClient.SendGauge("grpc_benchtool.latency_ns", float64(latency), []string{
+			"type:unary",
+			"server_id:" + s.ServerID,
+		})
+	}
+
+	return &pb.TestResponse{
+		ServerId:         s.ServerID,
+		ReceivedUnixNano: now,
+		LatencyNano:      latency,
+	}, nil
+}
+
+func (s *DefaultStrategy) HandleStream(stream pb.BenchService_StreamTestServer) error {
+	var count int64
+	var total int64
+	var latSumMs float64
+
+	for {
+		req, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		count++
+		total += int64(len(req.Payload))
+		latencyMs := float64(time.Now().UnixNano()-req.SentUnixNano) / 1e6
+		latSumMs += latencyMs
+	}
+
+	if s.MetricsClient != nil && count > 0 {
+		_ = s.MetricsClient.SendGauge("grpc_benchtool.stream.avg_latency_ms", latSumMs/float64(count), []string{
+			"type:stream",
+			"server_id:" + s.ServerID,
+		})
+	}
+
+	return stream.SendAndClose(&pb.StreamSummary{
+		ServerId:         s.ServerID,
+		ReceivedCount:    count,
+		TotalBytes:       total,
+		AverageLatencyMs: latSumMs / float64(count),
+	})
+}


### PR DESCRIPTION
This pull request introduces several significant changes to the gRPC benchmarking server, including the integration of Datadog for custom metrics, a refactor of server initialization, and improvements to logging. The most important changes are detailed below.

### Integration of Datadog for Custom Metrics:
* Added a new `DatadogClient` for sending custom metrics to Datadog. (`internal/metrics/datadog/client.go`, [internal/metrics/datadog/client.goR1-R41](diffhunk://#diff-70bb408a8b64659fef9c4eafddc956037dc4aa82f548b6fcad8e494a2cb04f00R1-R41))
* Implemented payload construction and transport functions for Datadog metrics. (`internal/metrics/datadog/payload.go`, [[1]](diffhunk://#diff-fba1c2d2364acf3b95234c7c89a4489873b166f75fceae8bae33a3538b7bbe68R1-R32); `internal/metrics/datadog/transport.go`, [[2]](diffhunk://#diff-c525cc719a7714e693b1a9c96e98bc1e2f2db1d579d4b596a53940ae9d2b26afR1-R36)

### Refactor of Server Initialization:
* Refactored server initialization to use a new `Server` struct and configuration. (`internal/server/config.go`, [[1]](diffhunk://#diff-48dafe60ad8f40099fe4d89ab4565c09e44399150ee62c2bfaa2ee502020c88bR1-R11); `internal/server/server.go`, [[2]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R1-R75)
* Updated `cmd/server.go` to use the new server configuration and initialization. (`cmd/server.go`, [cmd/server.goL5-L106](diffhunk://#diff-ee2560d627cd77f1563972217a33ac39a4bf56fbf30d7f560fbb4199b9f70197L5-L106))

### Improvements to Logging:
* Enhanced logging to support different log levels based on the `DEBUG` environment variable. (`internal/logging/slog.go`, [internal/logging/slog.goR32-R37](diffhunk://#diff-bb81005a7d943d3f82a60cf26b3ac9f25c60f99808d5a91b82389ac12f3b3cd7R32-R37))

### Strategy Pattern for Handling Requests:
* Introduced a `TestStrategy` interface and a `DefaultStrategy` implementation for handling unary and stream requests. (`internal/server/strategy.go`, [internal/server/strategy.goR1-R72](diffhunk://#diff-9bb71455c8a45182694af47766a1e7ee477b70c564c24296d53d16df3892e828R1-R72))
* Updated `BenchHandler` to use the new strategy pattern. (`internal/server/handler.go`, [internal/server/handler.goL5-R23](diffhunk://#diff-3ecdf2dea1e10258d744026a518738d2eacdfeb3015a8b462a88844d603b7748L5-R23))

### Miscellaneous:
* Modified `Makefile` to change the directory for extracting `protoc`. (`Makefile`, [MakefileL63-R63](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L63-R63))

These changes enhance the flexibility, maintainability, and observability of the gRPC benchmarking server.